### PR TITLE
整合配置类的get和all方法 

### DIFF
--- a/core/ppphp/conf.php
+++ b/core/ppphp/conf.php
@@ -14,46 +14,29 @@ class conf
     static public $conf = array();
     
     /**
-     * 加载系统配置,如果之前已经加载过,那么就直接返回
-     * @param string $name 配置名
+     * 加载系统配置文件,如果之前已经加载过,那么就直接返回所有配置或其中一个配置
      * @param string $file 文件名
-     * @return mix
+     * @param string $name 配置名
+     * @return mixed       找不到配置时返回false，当$name为空时返回文件所有配置，否则只返回$name这配置项
      */
-    static public function get($name,$file='conf')
+    static public function get($file='conf', $name=null)
     {
-        if(isset(self::$conf[$file][$name])) {
-            return self::$conf[$file][$name];
-        } else {
-            $conf = CORE.'config/'.$file.'.php';
-            if(is_file($conf)) {
-                self::$conf[$file] = include $conf;
-                    return isset(self::$conf[$file][$name])?self::$conf[$file][$name]:false;
-            } else {
+        // 判断配置没有缓存的话就导入配置文件并缓存
+        if (!isset(self::$conf[$file]))
+            // 判断配置文件是否存在
+            $conf = CORE.'config/' . $file . '.php';
+            if (!is_file($conf)) {
                 return false;
             }
+
+            self::$conf[$file] = include $conf;
         }
         
-    }
-    
-    /**
-     * 加载系统配置文件(直接加载整个配置文件),如果之前已经加载过,那么就直接返回
-     * @param string $name 配置名
-     * @param string $file 文件名
-     * @return mix
-     */
-    static public function all($file)
-    {
-        if(isset(self::$conf[$file])) {
+        // 如果$name为null则返回所有的设置
+        if (is_null($name)) {
             return self::$conf[$file];
-        } else {
-            $conf = CORE.'config/'.$file.'.php';
-            if(is_file($conf)) {
-                self::$conf[$file] = include $conf;
-                return self::$conf[$file];
-            } else {
-                return false;
-            }
         }
         
+        // 判断配置项是否存在并返回
+        return isset(self::$conf[$file][$name]) ? self::$conf[$file][$name] : false;
     }
-}

--- a/core/ppphp/route.php
+++ b/core/ppphp/route.php
@@ -13,7 +13,7 @@ class route
     public $route;
     public function __construct()
     {
-        $route = conf::all('route');
+        $route = conf::get('route');
         if(isset($_SERVER['REQUEST_URI'])) {
             $pathstr = str_replace($_SERVER['SCRIPT_NAME'],'',$_SERVER['REQUEST_URI']);
             //丢掉?以及后面的参数
@@ -56,8 +56,8 @@ class route
             }
         } else {
             
-            $this->ctrl = conf::get('DEFAULT_CTRL','route');
-            $this->action = conf::get('DEFAULT_ACTION','route');
+            $this->ctrl = conf::get('route', 'DEFAULT_CTRL');
+            $this->action = conf::get('route', 'DEFAULT_ACTION');
         }
     }
 


### PR DESCRIPTION
修复get方法的一个bug：当配置文件已缓存而$name不存在时，没有正确返回false。
整合get和all方法：两者的代码相似度太高，可以重用封装一个方法
