### PR TITLE
解决非80端口 无法访问 除默认模块以外的模块 和 国外VPS默认时区的问题

### DIFF
--- a/public/index.php
+++ b/public/index.php
@@ -9,11 +9,12 @@ if ($_SERVER['SERVER_NAME'] == 'ppphpadmin.m.com' || $_SERVER['SERVER_NAME'] == 
     $MODULE_NAME = 'app';
 }
 define('DEBUG', true);//调试模式
-
 define('PPPHP', realpath('./../'));    // 根目录
 //系统路径
 define('CORE', PPPHP . '/core/');
 define('APP', PPPHP . '/' . $MODULE_NAME . '/');
 define('MODULE', $MODULE_NAME);
+date_default_timezone_set('Asia/Shanghai');
+ini_set('date.timezone','Asia/Shanghai');
 //载入composer
 include PPPHP . '/vendor/autoload.php';

--- a/public/index.php
+++ b/public/index.php
@@ -3,7 +3,7 @@
  * PPPHP入口文件，用于定义常量
  * ======================================================================== */
 //如果是多模块,可以通过动态设置module的形式,动态条用不同模块
-if ($_SERVER['HTTP_HOST'] == 'ppphpadmin.m.com' || $_SERVER['HTTP_HOST'] == 'ppphpadmin.kphcdr.com') {
+if ($_SERVER['SERVER_NAME'] == 'ppphpadmin.m.com' || $_SERVER['SERVER_NAME'] == 'ppphpadmin.kphcdr.com') {
     $MODULE_NAME = 'admin';
 } else {
     $MODULE_NAME = 'app';


### PR DESCRIPTION
修改HTTP_HOST 改为 SERVER_NAME  解决非80端口 无法访问 除默认app模块以外的 模块
增加默认时区(GTM+8) 晚上 国外VPS假设 时间错乱问题。